### PR TITLE
Updating to r4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
         <!-- Project depencies versions -->
         <aerogear.bom.version>0.2.4</aerogear.bom.version>
-        <android.version>4.4.2_r3</android.version>
+        <android.version>4.4.2_r4</android.version>
         <aerogear.android.core.version>2.0.0-SNAPSHOT</aerogear.android.core.version>
         <aerogear.android.security.version>2.0.0-SNAPSHOT</aerogear.android.security.version>
 


### PR DESCRIPTION
Updating Android dependency.

Steps to test:
Update your SDK
Update your Maven SDK Deployer

delete ~/.m2/repository/android

run `mvn clean install` in the sdk deployer and then in -store.

If updating the SDK deployer fails, delete $ANDROID_HOME/add-ons/addon-google_apis-google-19-1 and rerun
Also check the -store pom.xml and make sure any other aerogear modules you may be missing are installed.
