### PR TITLE
Dropping support for old Android versions

### DIFF
--- a/aerogear-android-store-test/src/main/AndroidManifest.xml
+++ b/aerogear-android-store-test/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.jboss.aerogear.android.store.test">
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="19"/>
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21"/>
 
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>

--- a/aerogear-android-store/src/main/AndroidManifest.xml
+++ b/aerogear-android-store/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.jboss.aerogear.android.store">
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="19"/>
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21"/>
 </manifest>


### PR DESCRIPTION
We are dropping support for the old Android versions. For more informations see [Android Dashboard](https://developer.android.com/about/dashboards/index.html)

Jira: [AGDROID-310](https://issues.jboss.org/browse/AGDROID-310)
