### PR TITLE
Map dot key

### DIFF
--- a/aerogear-android-store-test/src/main/java/org/jboss/aerogear/android/store/test/sql/SQLStoreTest.java
+++ b/aerogear-android-store-test/src/main/java/org/jboss/aerogear/android/store/test/sql/SQLStoreTest.java
@@ -34,8 +34,11 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -381,6 +384,26 @@ public class SQLStoreTest extends PatchedActivityInstrumentationTestCase {
         store.close();
     }
 
+    @Test
+    public void testSaveItemWithMap() {
+        TrivialNestedMap trivialNestedMap = new TrivialNestedMap();
+        trivialNestedMap.setId(1);
+        Map<String, String> data = new HashMap<>();
+        trivialNestedMap.setData(data);
+
+        String key = "dot.breaks";
+        data.put(key, "value");
+        SQLStore<TrivialNestedMap> store = new SQLStore<>(TrivialNestedMap.class, context);
+        store.openSync();
+        store.save(trivialNestedMap);
+
+        Collection<TrivialNestedMap> result = store.readAll();
+
+        Assert.assertTrue(!result.isEmpty());
+        Assert.assertTrue(result.iterator().next().getData().containsKey(key));
+        store.close();
+    }
+
     private void loadBulkData() throws InterruptedException {
         saveData(1, "name", "description");
         saveData(2, "name", "description");
@@ -388,6 +411,28 @@ public class SQLStoreTest extends PatchedActivityInstrumentationTestCase {
         saveData(4, "name2", "description");
         saveData(5, "name", "description2");
         saveData(6, "name2", "description2");
+    }
+
+    public static final class TrivialNestedMap {
+        @RecordId
+        private Integer id;
+        private Map<String, String> data;
+
+        public Integer getId() {
+            return id;
+        }
+
+        public void setId(Integer id) {
+            this.id = id;
+        }
+
+        public Map<String, String> getData() {
+            return data;
+        }
+
+        public void setData(Map<String, String> data) {
+            this.data = data;
+        }
     }
 
     public static final class TrivialNestedClass {

--- a/aerogear-android-store-test/src/main/java/org/jboss/aerogear/android/store/test/sql/SQLStoreTest.java
+++ b/aerogear-android-store-test/src/main/java/org/jboss/aerogear/android/store/test/sql/SQLStoreTest.java
@@ -20,11 +20,14 @@ import android.content.Context;
 import android.os.StrictMode;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.RenamingDelegatingContext;
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
 import org.jboss.aerogear.android.core.Callback;
 import org.jboss.aerogear.android.store.DataManager;
 import org.jboss.aerogear.android.core.ReadFilter;
 import org.jboss.aerogear.android.core.RecordId;
 import org.jboss.aerogear.android.store.Store;
+import org.jboss.aerogear.android.store.generator.DefaultIdGenerator;
 import org.jboss.aerogear.android.store.sql.SQLStore;
 import org.jboss.aerogear.android.store.test.helper.Data;
 import org.jboss.aerogear.android.store.test.util.PatchedActivityInstrumentationTestCase;
@@ -33,10 +36,12 @@ import org.jboss.aerogear.android.store.test.MainActivity;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -393,7 +398,10 @@ public class SQLStoreTest extends PatchedActivityInstrumentationTestCase {
 
         String key = "dot.breaks";
         data.put(key, "value");
-        SQLStore<TrivialNestedMap> store = new SQLStore<>(TrivialNestedMap.class, context);
+        Type type = new TypeToken<Map<String, String>>() {}.getType();
+        GsonBuilder gsonBuilder = new GsonBuilder()
+                .registerTypeAdapter(type, MapAsArrayTypeAdapter.get(String.class, String.class));
+        SQLStore<TrivialNestedMap> store = new SQLStore<>(TrivialNestedMap.class, context, gsonBuilder, new DefaultIdGenerator());
         store.openSync();
         store.save(trivialNestedMap);
 
@@ -520,6 +528,46 @@ public class SQLStoreTest extends PatchedActivityInstrumentationTestCase {
             this.id = id;
         }
 
+    }
+
+    public static final class MapAsArrayTypeAdapter<K, V>
+            implements JsonSerializer<Map<K, V>>, JsonDeserializer<Map<K, V>> {
+        private final TypeToken<K> keyType;
+        private final TypeToken<V> valueType;
+
+        private MapAsArrayTypeAdapter(TypeToken<K> keyType, TypeToken<V> valueType) {
+            this.keyType = keyType;
+            this.valueType = valueType;
+        }
+
+        public static <K, V> MapAsArrayTypeAdapter<K, V> get(Class<K> keyType, Class<V> valueType) {
+            return new MapAsArrayTypeAdapter<K, V>(TypeToken.get(keyType), TypeToken.get(valueType));
+        }
+
+        public static <K, V> MapAsArrayTypeAdapter<K, V> get(
+                TypeToken<K> keyType, TypeToken<V> valueType) {
+            return new MapAsArrayTypeAdapter<K, V>(keyType, valueType);
+        }
+
+        public Map<K, V> deserialize(JsonElement json, Type typeOfT,
+                                     JsonDeserializationContext context) throws JsonParseException {
+            Map<K, V> result = new LinkedHashMap<K, V>();
+            JsonArray array = json.getAsJsonArray();
+            for (int i = 0; i < array.size(); i+=2) {
+                result.put(context.<K>deserialize(array.get(i), keyType.getType()),
+                        context.<V>deserialize(array.get(i + 1), valueType.getType()));
+            }
+            return result;
+        }
+
+        public JsonElement serialize(Map<K, V> src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonArray result = new JsonArray();
+            for (Map.Entry<K, V> entry : src.entrySet()) {
+                result.add(context.serialize(entry.getKey(), keyType.getType()));
+                result.add(context.serialize(entry.getValue(), valueType.getType()));
+            }
+            return result;
+        }
     }
 
 }

--- a/aerogear-android-store/pom.xml
+++ b/aerogear-android-store/pom.xml
@@ -87,12 +87,6 @@
             <scope>compile</scope>
         </dependency>
 
-       <dependency>
-           <groupId>com.google.guava</groupId>
-           <artifactId>guava</artifactId>
-           <version>19.0</version>
-       </dependency>
-
     </dependencies>
 
     <build>

--- a/aerogear-android-store/pom.xml
+++ b/aerogear-android-store/pom.xml
@@ -87,6 +87,12 @@
             <scope>compile</scope>
         </dependency>
 
+       <dependency>
+           <groupId>com.google.guava</groupId>
+           <artifactId>guava</artifactId>
+           <version>19.0</version>
+       </dependency>
+
     </dependencies>
 
     <build>

--- a/aerogear-android-store/src/main/java/org/jboss/aerogear/android/store/sql/SQLStore.java
+++ b/aerogear-android-store/src/main/java/org/jboss/aerogear/android/store/sql/SQLStore.java
@@ -23,6 +23,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 import android.os.AsyncTask;
 import android.util.Log;
 import android.util.Pair;
+import com.google.common.base.Joiner;
 import com.google.gson.*;
 import org.jboss.aerogear.android.core.Callback;
 import org.jboss.aerogear.android.core.ReadFilter;
@@ -427,7 +428,7 @@ public class SQLStore<T> extends SQLiteOpenHelper implements Store<T> {
 
                     add(subObject, names[1], propertyValue);
                 } else {
-                    result.addProperty(String.join(".", names), propertyValue);
+                    result.addProperty(Joiner.on(".").join(names), propertyValue);
                 }
             }
         }

--- a/aerogear-android-store/src/main/java/org/jboss/aerogear/android/store/sql/SQLStore.java
+++ b/aerogear-android-store/src/main/java/org/jboss/aerogear/android/store/sql/SQLStore.java
@@ -21,9 +21,9 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.AsyncTask;
+import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
-import com.google.common.base.Joiner;
 import com.google.gson.*;
 import org.jboss.aerogear.android.core.Callback;
 import org.jboss.aerogear.android.core.ReadFilter;
@@ -428,7 +428,7 @@ public class SQLStore<T> extends SQLiteOpenHelper implements Store<T> {
 
                     add(subObject, names[1], propertyValue);
                 } else {
-                    result.addProperty(Joiner.on(".").join(names), propertyValue);
+                    result.addProperty(TextUtils.join(".", names), propertyValue);
                 }
             }
         }

--- a/aerogear-android-store/src/main/java/org/jboss/aerogear/android/store/sql/SQLStore.java
+++ b/aerogear-android-store/src/main/java/org/jboss/aerogear/android/store/sql/SQLStore.java
@@ -419,13 +419,26 @@ public class SQLStore<T> extends SQLiteOpenHelper implements Store<T> {
             } else {
 
                 JsonObject subObject = (JsonObject) result.get(names[0]);
-                if (subObject == null) {
-                    subObject = new JsonObject();
-                    result.add(names[0], subObject);
-                }
+                if (hasField(names[0])) {
+                    if (subObject == null) {
+                        subObject = new JsonObject();
+                        result.add(names[0], subObject);
+                    }
 
-                add(subObject, names[1], propertyValue);
+                    add(subObject, names[1], propertyValue);
+                } else {
+                    result.addProperty(String.join(".", names), propertyValue);
+                }
             }
+        }
+    }
+
+    private boolean hasField(String name) {
+        try {
+            klass.getDeclaredField(name);
+            return true;
+        } catch (NoSuchFieldException e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
@secondsun @danielpassos this fix uses the class to see if the field exists when separating on '.' when not it concatenates the string and uses the entire thing as a property. WDYT?

Jira: [AGDROID-564](https://issues.jboss.org/browse/AGDROID-564)